### PR TITLE
fix(bool): lazy function evaluation in case of and/or operations

### DIFF
--- a/lib/ex_pression/interpreter.ex
+++ b/lib/ex_pression/interpreter.ex
@@ -110,6 +110,40 @@ defmodule ExPression.Interpreter do
     end
   end
 
+  # Python semantics for boolean ops
+
+  defp do_eval({:and, [a, b]}, context) do
+    a = do_eval(a, context)
+
+    cond do
+      is_tuple(a) ->
+        a
+
+      !a or a in @empty_values ->
+        a
+
+      true ->
+        b = do_eval(b, context)
+        a && b
+    end
+  end
+
+  defp do_eval({:or, [a, b]}, context) do
+    a = do_eval(a, context)
+
+    cond do
+      is_tuple(a) ->
+        a
+
+      a ->
+        a
+
+      true ->
+        b = do_eval(b, context)
+        a || b
+    end
+  end
+
   defp do_eval({op, [a, b]}, context) do
     with a when not is_tuple(a) <- do_eval(a, context),
          b when not is_tuple(b) <- do_eval(b, context) do
@@ -146,22 +180,6 @@ defmodule ExPression.Interpreter do
   end
 
   # Python semantics for boolean ops
-
-  defp eval_bin_op(:and, a, b) do
-    if a in @empty_values do
-      a
-    else
-      a && b
-    end
-  end
-
-  defp eval_bin_op(:or, a, b) do
-    if a in @empty_values do
-      b
-    else
-      a || b
-    end
-  end
 
   defp eval_bin_op(:==, a, b) do
     a == b

--- a/test/ex_pression/interpreter_test.exs
+++ b/test/ex_pression/interpreter_test.exs
@@ -11,6 +11,10 @@ defmodule ExPression.InterpreterTest do
     def concat(a, b, c) do
       "#{a}#{b}#{c}"
     end
+
+    def check_is_true(value) do
+      value == true
+    end
   end
 
   describe "#deep inside" do
@@ -119,6 +123,16 @@ defmodule ExPression.InterpreterTest do
     test "bool 5" do
       {:ok, ast} = Parser.parse("1 != 1")
       assert {:ok, false} == Interpreter.eval(ast)
+    end
+
+    test "bool(and): ignore right part if left is false" do
+      {:ok, ast} = Parser.parse("check_is_true(false) and 1 / 0")
+      assert {:ok, false} == Interpreter.eval(ast, %{}, TestModule)
+    end
+
+    test "bool(or): ignore right part if left is true" do
+      {:ok, ast} = Parser.parse("check_is_true(true) or 1 / 0")
+      assert {:ok, true} == Interpreter.eval(ast, %{}, TestModule)
     end
 
     test "array 1" do


### PR DESCRIPTION
Lazy function evaluation in case of and/or operations

Before:
```iex
iex(6)> defmodule TestModule do
...(6)>   def check_is_true(value), do: value == true
...(6)> end

iex(7)> {:ok, ast} = ExPression.parse("check_is_true(false) and 1 / 0")
{:ok, {:and, [fun_call: ["check_is_true", false], /: [1, 0]]}}

iex(8)> ExPression.Interpreter.eval(ast, %{}, TestModule)
** (ArithmeticError) bad argument in arithmetic expression
    (ex_pression 0.7.0) lib/ex_pression/interpreter.ex:129: ExPression.Interpreter.eval_bin_op/3
    (ex_pression 0.7.0) lib/ex_pression/interpreter.ex:115: ExPression.Interpreter.do_eval/2
    (ex_pression 0.7.0) lib/ex_pression/interpreter.ex:13: ExPression.Interpreter.eval/3
    iex:8: (file)
```

After:
```iex
iex(1)> defmodule TestModule do
...(1)>   def check_is_true(value), do: value == true
...(1)> end

iex(2)> {:ok, ast} = ExPression.parse("check_is_true(false) and 1 / 0")
{:ok, {:and, [fun_call: ["check_is_true", false], /: [1, 0]]}}

iex(3)> ExPression.Interpreter.eval(ast, %{}, TestModule)
{:ok, false}
```